### PR TITLE
Add freej2me (unsure about this)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,11 @@ stages:
   variables:
     MEDIA_PATH: .media
   script:
+    # freej2me: Install ant
+    - apt-get update -q -y
+    - apt-get install -y ant
+
+    # Build the system files
     - mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}
     - ./make.sh
     - cp out/.index ${MEDIA_PATH}/${CI_PROJECT_NAME}

--- a/scripts/freej2me.sh
+++ b/scripts/freej2me.sh
@@ -34,7 +34,7 @@ cd "$BUILD_DIR"
 rm -rf "$SYSTEM_DIR"
 mkdir "$SYSTEM_DIR"
 cp "${REPO_PATH}/build/freej2me-lr.jar" "$SYSTEM_DIR"
-cp -r "${REPO_PATH}/LICENSE" "$SYSTEM_DIR/freej2me-license.txt"
+cp -r "${REPO_PATH}/LICENSE" "$SYSTEM_DIR/freej2me-license"
 
 rm -f "$ARCHIVE_FILE"
 7z a -mx9 "$ARCHIVE_FILE" "$SYSTEM_DIR/." # Don't have the sub-folder

--- a/scripts/freej2me.sh
+++ b/scripts/freej2me.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(dirname $(which $0))"
+source "$(realpath "${SCRIPT_DIR}/lib/common.sh")"
+
+REPO_URL="https://github.com/hex007/freej2me.git"
+REPO_NAME="freej2me"
+REPO_PATH="${SRC_REPOS_DIR}/${REPO_NAME}"
+
+SYSTEM_DIR="freej2me"
+ARCHIVE_FILE="${OUT_DIR}/freej2me.zip"
+
+if ! update_src_repo "$REPO_URL" "$REPO_NAME"
+then
+	exit 1
+fi
+
+# Build the library
+cd "$REPO_PATH"
+
+# Requires "ant" to build the library
+# https://ant.apache.org/
+if ! which ant
+then
+    echo "freej2me: Missing 'ant'"
+    exit 1
+fi
+
+cd "$BUILD_DIR"
+
+rm -rf "$SYSTEM_DIR"
+mkdir "$SYSTEM_DIR"
+cp "${REPO_PATH}/build/freej2me-lr.jar" "$SYSTEM_DIR"
+cp -r "${REPO_PATH}/LICENSE" "$SYSTEM_DIR/freej2me-license.txt"
+
+rm -f "$ARCHIVE_FILE"
+7z a -mx9 "$ARCHIVE_FILE" "$SYSTEM_DIR/." # Don't have the sub-folder
+rm -rf "$SYSTEM_DIR"

--- a/scripts/freej2me.sh
+++ b/scripts/freej2me.sh
@@ -17,16 +17,17 @@ then
 	exit 1
 fi
 
-# Build the library
-cd "$REPO_PATH"
-
 # Requires "ant" to build the library
 # https://ant.apache.org/
 if ! which ant
 then
-    echo "freej2me: Missing 'ant'"
+    echo "freej2me: Missing 'ant'. Install ant to continue."
     exit 1
 fi
+
+# Build the library
+cd "$REPO_PATH"
+ant
 
 cd "$BUILD_DIR"
 


### PR DESCRIPTION
This adds the freej2me system file. I'm unsure about this though, since it requires ant, and can have a different checksum for each build. May be easier to package it as part of the libretro-content repo? I'm unsure. I understand we can't have binary files in here, so where would be the best place to store it?
